### PR TITLE
Test BCryptGenRandom

### DIFF
--- a/crypto/rand/rand_win.c
+++ b/crypto/rand/rand_win.c
@@ -66,8 +66,28 @@ size_t rand_pool_acquire_entropy(RAND_POOL *pool)
     buffer = rand_pool_add_begin(pool, bytes_needed);
     if (buffer != NULL) {
         size_t bytes = 0;
-        if (BCryptGenRandom(NULL, buffer, bytes_needed,
-                            BCRYPT_USE_SYSTEM_PREFERRED_RNG) == STATUS_SUCCESS)
+        NTSTATUS status;
+
+        fprintf(stderr, "_WIN32_WINNT = 0x%08X\n", _WIN32_WINNT);
+        status = BCryptGenRandom(NULL, buffer, bytes_needed,
+                        BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+
+        switch (status) {
+        case STATUS_SUCCESS:
+            fprintf(stderr, "BCryptGenRandom() returned STATUS_SUCCESS\n");
+            break;
+        case STATUS_INVALID_HANDLE:
+            fprintf(stderr, "BCryptGenRandom() returned STATUS_INVALID_HANDLE\n");
+            break;
+        case STATUS_INVALID_PARAMETER:
+            fprintf(stderr, "BCryptGenRandom() returned STATUS_INVALID_PARAMETER\n");
+            break;
+        default:
+            fprintf(stderr, "BCryptGenRandom() returned 0x%08x\n", status);
+            break;
+        }
+
+        if (status == STATUS_SUCCESS)
             bytes = bytes_needed;
 
         rand_pool_add_end(pool, bytes, 8 * bytes);


### PR DESCRIPTION

Adds some test output to openssl for testing
BCryptGenRandom(..., BCRYPT_USE_SYSTEM_PREFERRED_RNG)
on Windows Vista.

Here is the output I got using Windows Vista SP2

```
Microsoft Windows [Version 6.0.6002]
Copyright (c) 2006 Microsoft Corporation. Alle Rechte vorbehalten.

C:\Users\msp>openssl rand -hex 10
_WIN32_WINNT = 0x00000603
BCryptGenRandom() returned STATUS_SUCCESS
37a655fb82d04c43e694
```

So it looks like the [MSDN Documentation](https://docs.microsoft.com/en-us/windows/desktop/api/bcrypt/nf-bcrypt-bcryptgenrandom) is outdated.



![Windows Vista SP2](https://user-images.githubusercontent.com/11467854/55596462-e1db0580-5748-11e9-9321-247cb3b511f7.png)
